### PR TITLE
Performance improvement for default now return

### DIFF
--- a/SORelativeDateTransformer/SORelativeDateTransformer.m
+++ b/SORelativeDateTransformer/SORelativeDateTransformer.m
@@ -76,9 +76,7 @@ static inline NSString *SORelativeDateLocalizedString(NSString *key, NSString *c
 		return SORelativeDateLocalizedString(@"now", @"label for current date-time");
 	}
 	
-	// Default return value is "now".
-	
-	id transformedValue = SORelativeDateLocalizedString(@"now", @"label for current date-time");
+	id transformedValue = nil;
 	
 	// Obtain the date components for the relative difference between the input date and now.
 	
@@ -142,6 +140,10 @@ static inline NSString *SORelativeDateLocalizedString(NSString *key, NSString *c
 		
 	} // for loop
 	
+	// Default return value is "now".
+	if (!transformedValue) {
+		transformedValue = SORelativeDateLocalizedString(@"now", @"label for current date-time");
+	}
 	
 	return transformedValue;
 }


### PR DESCRIPTION
This is a quick modification that looks up the now value only if the transformedValue is nil when it's about to be returned. In our app, Couple, we noticed a slowdown from the repetitive lookup of the now value at every relative date transform which happens a lot when you scroll through our timeline of messages.
