### PR TITLE
Update the API to use class method.

### DIFF
--- a/SORelativeDateTransformer/SORelativeDateTransformer.h
+++ b/SORelativeDateTransformer/SORelativeDateTransformer.h
@@ -41,5 +41,6 @@ SORelativeDateTransformer is a value transformer that generates a human-readable
 \return An NSString with the generated and localized phrase.
 */
 - (id) transformedValue:(id)value;
++ (id) transformedValue:(id)value;
 
 @end

--- a/SORelativeDateTransformer/SORelativeDateTransformer.m
+++ b/SORelativeDateTransformer/SORelativeDateTransformer.m
@@ -13,6 +13,8 @@
 #define __has_feature(x) 0
 #endif
 
+static SORelativeDateTransformer *_sharedInstance;
+
 @implementation SORelativeDateTransformer
 
 + (NSBundle *)bundle {
@@ -148,5 +150,16 @@ static inline NSString *SORelativeDateLocalizedString(NSString *key, NSString *c
 	return transformedValue;
 }
 
++ (SORelativeDateTransformer *)shardTransformer{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _sharedInstance = [[self alloc] init];
+    });
+    return _sharedInstance;
+}
+
++ (id)transformedValue:(id)value{
+    return [[self shardTransformer] transformedValue:value];
+}
 
 @end


### PR DESCRIPTION
So it could be used like this:

```
   [SORelativeDateTransformer transformedValue:[datePicker date]]];
```
