### PR TITLE
add calendar property to allow customization

### DIFF
--- a/SORelativeDateTransformer/SORelativeDateTransformer.h
+++ b/SORelativeDateTransformer/SORelativeDateTransformer.h
@@ -43,6 +43,13 @@
 + (NSValueTransformer *) registeredTransformer;
 
 /**
+ @brief Calendar used to compute date relative difference.
+ 
+ +[NSCalendar autoupdatingCurrentCalendar] will be used as default calendar if not set.
+ */
+@property (nonatomic, strong) NSCalendar *calendar;
+
+/**
  @brief Transform an NSDate into a phrase expressing the relative difference between that date and now.
  @param value An NSDate to be compared to the current date.
  @return An NSString with the generated and localized phrase.

--- a/SORelativeDateTransformer/SORelativeDateTransformer.m
+++ b/SORelativeDateTransformer/SORelativeDateTransformer.m
@@ -10,6 +10,8 @@
 
 @implementation SORelativeDateTransformer
 
+@synthesize calendar = __calendar;
+
 + (NSValueTransformer *) registeredTransformer
 {
     return [NSValueTransformer valueTransformerForName:NSStringFromClass(self)];


### PR DESCRIPTION
Customize `NSCalendar` instance used by `SORelativeDateTransformer` might be a common use case.

In our app, we want to set the timezone of the `NSCalendar` instance, but since it's a private ivar, we can not do that. In this PR, `calendar` property is added so users can customize it as they need.
